### PR TITLE
feat: 회원가입 서버 구축 및 로그인 기능 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
 	kotlin("jvm") version "1.9.25"
 	kotlin("plugin.spring") version "1.9.25"
-	id("org.springframework.boot") version "3.4.2"
-	id("io.spring.dependency-management") version "1.1.7"
+	id("org.springframework.boot") version "3.3.4"
+	id("io.spring.dependency-management") version "1.1.6"
 	kotlin("plugin.jpa") version "1.9.25"
 }
 
@@ -11,7 +11,7 @@ version = "0.0.1-SNAPSHOT"
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
+		languageVersion = JavaLanguageVersion.of(21)
 	}
 }
 
@@ -23,10 +23,15 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+	implementation("com.mysql:mysql-connector-j")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	testImplementation("io.mockk:mockk:1.13.13")
+	testImplementation("com.ninja-squad:springmockk:4.0.2")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/main/kotlin/com/example/yum_signup_server/common/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/common/config/SwaggerConfig.kt
@@ -1,0 +1,20 @@
+package com.example.yum_signup_server.common.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+    @Bean
+    fun openApi(): OpenAPI = OpenAPI()
+        .components(Components())
+        .info(swaggerInfo())
+
+    private fun swaggerInfo(): Info = Info()
+        .title("Yum 회원가입 및 로그인 API")
+        .description("A&I 프로젝트 회원가입 및 로그인 서버의 API 명세서")
+        .version("1.0.0")
+}

--- a/src/main/kotlin/com/example/yum_signup_server/member/controller/LoginController.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/controller/LoginController.kt
@@ -1,0 +1,4 @@
+package com.example.yum_signup_server.member.controller
+
+class LoginController {
+}

--- a/src/main/kotlin/com/example/yum_signup_server/member/controller/LoginController.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/controller/LoginController.kt
@@ -2,6 +2,7 @@ package com.example.yum_signup_server.member.controller
 
 import com.example.yum_signup_server.member.dto.LoginDto
 import com.example.yum_signup_server.member.service.LoginService
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/api/login")
 class LoginController(private val loginService: LoginService) {
 
+    @Operation(summary = "로그인 API", description = "이메일과 비밀번호를 입력받아 인증을 수행합니다.")
     @PostMapping
     fun loginUser(@RequestBody loginDto: LoginDto): ResponseEntity<String> {
         return if (loginService.authenticateUser(loginDto)) {

--- a/src/main/kotlin/com/example/yum_signup_server/member/controller/LoginController.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/controller/LoginController.kt
@@ -1,4 +1,20 @@
 package com.example.yum_signup_server.member.controller
 
-class LoginController {
+import com.example.yum_signup_server.member.dto.LoginDto
+import com.example.yum_signup_server.member.service.LoginService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/login")
+class LoginController(private val loginService: LoginService) {
+
+    @PostMapping
+    fun loginUser(@RequestBody loginDto: LoginDto): ResponseEntity<String> {
+        return if (loginService.authenticateUser(loginDto)) {
+            ResponseEntity.ok("로그인 성공!")
+        } else {
+            ResponseEntity.status(401).body("로그인 실패!")
+        }
+    }
 }

--- a/src/main/kotlin/com/example/yum_signup_server/member/controller/SignupController.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/controller/SignupController.kt
@@ -1,0 +1,4 @@
+package com.example.yum_signup_server.member.controller
+
+class SignupController {
+}

--- a/src/main/kotlin/com/example/yum_signup_server/member/controller/SignupController.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/controller/SignupController.kt
@@ -2,6 +2,7 @@ package com.example.yum_signup_server.member.controller
 
 import com.example.yum_signup_server.member.dto.SignupDto
 import com.example.yum_signup_server.member.service.SignupService
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/api/signup")
 class SignupController(private val signupService: SignupService) {
 
+    @Operation(summary = "회원가입 API", description = "사용자가 회원가입을 요청하면 정보를 저장하고 성공 메시지를 반환합니다.")
     @PostMapping
     fun registerUser(@RequestBody signupDto: SignupDto): ResponseEntity<String> {
         signupService.registerUser(signupDto)

--- a/src/main/kotlin/com/example/yum_signup_server/member/controller/SignupController.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/controller/SignupController.kt
@@ -1,4 +1,17 @@
 package com.example.yum_signup_server.member.controller
 
-class SignupController {
+import com.example.yum_signup_server.member.dto.SignupDto
+import com.example.yum_signup_server.member.service.SignupService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/signup")
+class SignupController(private val signupService: SignupService) {
+
+    @PostMapping
+    fun registerUser(@RequestBody signupDto: SignupDto): ResponseEntity<String> {
+        signupService.registerUser(signupDto)
+        return ResponseEntity.ok("회원가입 성공!")
+    }
 }

--- a/src/main/kotlin/com/example/yum_signup_server/member/dto/LoginDto.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/dto/LoginDto.kt
@@ -1,0 +1,3 @@
+package com.example.yum_signup_server.member.dto
+
+data class LoginDto()

--- a/src/main/kotlin/com/example/yum_signup_server/member/dto/LoginDto.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/dto/LoginDto.kt
@@ -1,3 +1,6 @@
 package com.example.yum_signup_server.member.dto
 
-data class LoginDto()
+data class LoginDto(
+    val email: String,
+    val password: String
+)

--- a/src/main/kotlin/com/example/yum_signup_server/member/dto/MemberDtos.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/dto/MemberDtos.kt
@@ -1,0 +1,3 @@
+package com.example.yum_signup_server.member.dto
+
+data class MemberDtos()

--- a/src/main/kotlin/com/example/yum_signup_server/member/dto/MemberDtos.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/dto/MemberDtos.kt
@@ -1,3 +1,8 @@
 package com.example.yum_signup_server.member.dto
 
-data class MemberDtos()
+data class MemberResponseDto(
+    val id: Long,
+    val email: String,
+    val name: String,
+    val role: String
+)

--- a/src/main/kotlin/com/example/yum_signup_server/member/dto/SignupDto.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/dto/SignupDto.kt
@@ -1,3 +1,7 @@
 package com.example.yum_signup_server.member.dto
 
-data class SignupDto()
+data class SignupDto(
+    val email: String,
+    val password: String,
+    val name: String
+)

--- a/src/main/kotlin/com/example/yum_signup_server/member/dto/SignupDto.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/dto/SignupDto.kt
@@ -1,0 +1,3 @@
+package com.example.yum_signup_server.member.dto
+
+data class SignupDto()

--- a/src/main/kotlin/com/example/yum_signup_server/member/entity/Member.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/entity/Member.kt
@@ -1,12 +1,12 @@
 package com.example.yum_signup_server.member.entity
 
 import jakarta.persistence.*
-import org.springframework.data.annotation.Id
 
 @Entity
 @Table(name = "members")
 data class Member(
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
 
     @Column(nullable = false, unique = true)

--- a/src/main/kotlin/com/example/yum_signup_server/member/entity/Member.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/entity/Member.kt
@@ -1,0 +1,4 @@
+package com.example.yum_signup_server.member.entity
+
+class Member {
+}

--- a/src/main/kotlin/com/example/yum_signup_server/member/entity/Member.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/entity/Member.kt
@@ -1,4 +1,23 @@
 package com.example.yum_signup_server.member.entity
 
-class Member {
-}
+import jakarta.persistence.*
+import org.springframework.data.annotation.Id
+
+@Entity
+@Table(name = "members")
+data class Member(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Column(nullable = false, unique = true)
+    val email: String,
+
+    @Column(nullable = false)
+    val password: String,
+
+    @Column(nullable = false)
+    val name: String,
+
+    @Enumerated(EnumType.STRING)
+    val role: MemberRole = MemberRole.USER
+)

--- a/src/main/kotlin/com/example/yum_signup_server/member/entity/MemberRole.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/entity/MemberRole.kt
@@ -1,4 +1,5 @@
 package com.example.yum_signup_server.member.entity
 
-class MemberRole {
+enum class MemberRole {
+    USER, ADMIN
 }

--- a/src/main/kotlin/com/example/yum_signup_server/member/entity/MemberRole.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/entity/MemberRole.kt
@@ -1,0 +1,4 @@
+package com.example.yum_signup_server.member.entity
+
+class MemberRole {
+}

--- a/src/main/kotlin/com/example/yum_signup_server/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/repository/MemberRepository.kt
@@ -1,4 +1,9 @@
 package com.example.yum_signup_server.member.repository
 
-interface MemberRepository {
+import com.example.yum_signup_server.member.entity.Member
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.*
+
+interface MemberRepository : JpaRepository<Member, Long> {
+    fun findByEmail(email: String): Optional<Member>
 }

--- a/src/main/kotlin/com/example/yum_signup_server/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/repository/MemberRepository.kt
@@ -1,0 +1,4 @@
+package com.example.yum_signup_server.member.repository
+
+interface MemberRepository {
+}

--- a/src/main/kotlin/com/example/yum_signup_server/member/service/LoginService.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/service/LoginService.kt
@@ -1,0 +1,4 @@
+package com.example.yum_signup_server.member.service
+
+class LoginService {
+}

--- a/src/main/kotlin/com/example/yum_signup_server/member/service/LoginService.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/service/LoginService.kt
@@ -1,4 +1,22 @@
 package com.example.yum_signup_server.member.service
 
-class LoginService {
+import com.example.yum_signup_server.member.dto.LoginDto
+import com.example.yum_signup_server.member.repository.MemberRepository
+import org.springframework.stereotype.Service
+import java.security.MessageDigest
+
+@Service
+class LoginService(private val memberRepository: MemberRepository) {
+
+    fun authenticateUser(loginDto: LoginDto): Boolean {
+        val user = memberRepository.findByEmail(loginDto.email)
+            .orElseThrow { IllegalArgumentException("이메일이 존재하지 않습니다.") }
+
+        return hashPassword(loginDto.password) == user.password
+    }
+
+    private fun hashPassword(password: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        return digest.digest(password.toByteArray()).joinToString("") { "%02x".format(it) }
+    }
 }

--- a/src/main/kotlin/com/example/yum_signup_server/member/service/MemberService.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/service/MemberService.kt
@@ -1,0 +1,4 @@
+package com.example.yum_signup_server.member.service
+
+class MemberService {
+}

--- a/src/main/kotlin/com/example/yum_signup_server/member/service/SignupService.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/service/SignupService.kt
@@ -1,4 +1,30 @@
 package com.example.yum_signup_server.member.service
 
-class SignupService {
+import com.example.yum_signup_server.member.dto.SignupDto
+import com.example.yum_signup_server.member.entity.Member
+import com.example.yum_signup_server.member.repository.MemberRepository
+import org.springframework.stereotype.Service
+import java.security.MessageDigest
+
+@Service
+class SignupService(private val memberRepository: MemberRepository) {
+
+    fun registerUser(signupDto: SignupDto) {
+        if (memberRepository.findByEmail(signupDto.email).isPresent) {
+            throw IllegalArgumentException("이미 존재하는 이메일입니다.")
+        }
+
+        val hashedPassword = hashPassword(signupDto.password)
+        val newMember = Member(
+            email = signupDto.email,
+            password = hashedPassword,
+            name = signupDto.name
+        )
+        memberRepository.save(newMember)
+    }
+
+    private fun hashPassword(password: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        return digest.digest(password.toByteArray()).joinToString("") { "%02x".format(it) }
+    }
 }

--- a/src/main/kotlin/com/example/yum_signup_server/member/service/SignupService.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/service/SignupService.kt
@@ -1,0 +1,4 @@
+package com.example.yum_signup_server.member.service
+
+class SignupService {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=yum-signup-server

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  application:
+    name: yum-signup-server
+
+  datasource:
+    url: "jdbc:mysql://localhost:3306/signup?autoReconnect=true&useUnicode=true&serverTimezone=Asia/Seoul"
+    username: signup
+    password: signup
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    database-platform: org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
[회원가입 및 로그인 API 구현]

1. SignupController, LoginController 추가하여 API 엔드포인트 생성
-  SignupService, LoginService 추가하여 비즈니스 로직 구현
- Member 엔티티 및 MemberRepository 추가하여 JPA 활용

2.  SHA-256 비밀번호 해싱 적용
- SignupService에서 SHA-256 해싱을 적용하여 비밀번호 저장
- LoginService에서 사용자가 입력한 비밀번호를 해싱 후 DB 값과 비교

3. Swagger UI 적용
- springdoc-openapi-starter-webmvc-ui:2.5.0 추가
- /swagger-ui/index.html을 통해 API 문서 확인 가능