### PR TITLE
[MemberRepository, DTO 및 Service 코드 수정]

### DIFF
--- a/src/main/kotlin/com/example/yum_signup_server/member/dto/LoginDto.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/dto/LoginDto.kt
@@ -1,5 +1,10 @@
 package com.example.yum_signup_server.member.dto
 
+/**
+ * 로그인 요청을 위한 DTO
+ * 사용자가 입력한 이메일과 비밀번호를 포함
+ */
+
 data class LoginDto(
     val email: String,
     val password: String

--- a/src/main/kotlin/com/example/yum_signup_server/member/dto/MemberDtos.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/dto/MemberDtos.kt
@@ -1,5 +1,10 @@
 package com.example.yum_signup_server.member.dto
 
+/**
+ * 회원 정보를 응답 DTO
+ * ID, 이메일, 닉네임, 역할(role) 정보를 포함
+ */
+
 data class MemberResponseDto(
     val id: Long,
     val email: String,

--- a/src/main/kotlin/com/example/yum_signup_server/member/dto/SignupDto.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/dto/SignupDto.kt
@@ -1,5 +1,10 @@
 package com.example.yum_signup_server.member.dto
 
+/**
+ * 회원가입 요청 DTO
+ * 사용자가 입력한 이메일, 비밀번호, 닉네임을 포함
+ */
+
 data class SignupDto(
     val email: String,
     val password: String,

--- a/src/main/kotlin/com/example/yum_signup_server/member/entity/Member.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/entity/Member.kt
@@ -6,18 +6,23 @@ import jakarta.persistence.*
 @Table(name = "members")
 data class Member(
     @Id
+    // 회원 고유 ID
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
 
+    // 회원 이메일 (중복 불가)
     @Column(nullable = false, unique = true)
     val email: String,
 
+    // 회원 비밀번호
     @Column(nullable = false)
     val password: String,
 
+    // 회원의 닉네임
     @Column(nullable = false)
     val name: String,
 
+    // 회원 역할 (기본값 : USER)ß
     @Enumerated(EnumType.STRING)
     val role: MemberRole = MemberRole.USER
 )

--- a/src/main/kotlin/com/example/yum_signup_server/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/repository/MemberRepository.kt
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 import java.util.*
 
 interface MemberRepository : JpaRepository<Member, Long> {
-    fun findByEmail(email: String): Optional<Member>
+    fun findByEmail(email: String): Member?
 }

--- a/src/main/kotlin/com/example/yum_signup_server/member/service/LoginService.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/service/LoginService.kt
@@ -10,7 +10,7 @@ class LoginService(private val memberRepository: MemberRepository) {
 
     fun authenticateUser(loginDto: LoginDto): Boolean {
         val user = memberRepository.findByEmail(loginDto.email)
-            .orElseThrow { IllegalArgumentException("이메일이 존재하지 않습니다.") }
+            ?: throw IllegalArgumentException("이메일이 존재하지 않습니다.") // ✅ Optional → Kotlin null-safe 방식으로 변경
 
         return hashPassword(loginDto.password) == user.password
     }

--- a/src/main/kotlin/com/example/yum_signup_server/member/service/SignupService.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/service/SignupService.kt
@@ -2,6 +2,7 @@ package com.example.yum_signup_server.member.service
 
 import com.example.yum_signup_server.member.dto.SignupDto
 import com.example.yum_signup_server.member.entity.Member
+import com.example.yum_signup_server.member.entity.MemberRole
 import com.example.yum_signup_server.member.repository.MemberRepository
 import org.springframework.stereotype.Service
 import java.security.MessageDigest
@@ -18,7 +19,8 @@ class SignupService(private val memberRepository: MemberRepository) {
         val newMember = Member(
             email = signupDto.email,
             password = hashedPassword,
-            name = signupDto.name
+            name = signupDto.name,
+            role = MemberRole.USER
         )
         memberRepository.save(newMember)
     }

--- a/src/main/kotlin/com/example/yum_signup_server/member/service/SignupService.kt
+++ b/src/main/kotlin/com/example/yum_signup_server/member/service/SignupService.kt
@@ -10,7 +10,7 @@ import java.security.MessageDigest
 class SignupService(private val memberRepository: MemberRepository) {
 
     fun registerUser(signupDto: SignupDto) {
-        if (memberRepository.findByEmail(signupDto.email).isPresent) {
+        if (memberRepository.findByEmail(signupDto.email) != null) {
             throw IllegalArgumentException("이미 존재하는 이메일입니다.")
         }
 


### PR DESCRIPTION
1. MemberRepository 수정  
- findByEmail() 반환 타입을 Optional<Member> → Member?로 변경

 2. DTO 클래스에 역할 설명 주석 추가  
- LoginDto : 로그인 요청 시 이메일과 비밀번호 전달  
- MemberResponseDto : 회원 정보 응답 시 ID, 이메일, 닉네임, 역할 반환  
- SignupDto : 회원가입 요청 시 이메일, 비밀번호, 닉네임 전달  

3. SignupService 코드 수정  
- findByEmail()의 반환 타입 변경에 따라 isPresent() 코드문을 != null로 변경  
- 회원가입 시 role 기본값 USER로 설정하여 역할 지정  